### PR TITLE
refactor: simplify package definitions by removing overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,13 +23,9 @@
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
-        overlays = [
-          (final: prev: {
-            ghostty = (import nixpkgs-ghostty { inherit system; config.allowUnfree = true; }).ghostty;
-            arc-browser = (import nixpkgs-arc-browser { inherit system; config.allowUnfree = true; }).arc-browser;
-          })
-        ];
       };
+      ghostty = (import nixpkgs-ghostty { inherit system; config.allowUnfree = true; }).ghostty;
+      arc-browser = (import nixpkgs-arc-browser { inherit system; config.allowUnfree = true; }).arc-browser;
     in
     {
       darwinConfigurations."Mac-big" = nix-darwin.lib.darwinSystem {
@@ -46,9 +42,8 @@
 
               programs.zsh.enable = true;
 
-              environment.systemPackages = with pkgs; [
+              environment.systemPackages = (with pkgs; [
                 alt-tab-macos
-                arc-browser
                 devbox
                 discord
                 fzf
@@ -63,8 +58,7 @@
                 uv
                 vim
                 vscode
-                ghostty
-              ];
+              ]) ++ [ ghostty arc-browser ];
 
               nix.settings.experimental-features = "nix-command flakes";
 


### PR DESCRIPTION
## Summary
- Removed unnecessary overlay abstraction for ghostty and arc-browser
- Changed to direct package definitions which is more explicit
- Follows current Nix best practices for small numbers of pinned packages

## Changes
- Removed overlay definition from pkgs
- Added direct definitions for ghostty and arc-browser packages
- Updated systemPackages list to use concatenation for external packages

## Rationale
For a small number of packages (2 in this case), using overlays adds unnecessary abstraction. Direct definition is:
- More explicit and easier to understand
- Follows modern Nix/flake patterns
- Reduces complexity without losing functionality

Fixes #17

🤖 Generated with [Claude Code](https://claude.ai/code)