### PR TITLE
docs: remove Rectangle from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The configuration installs various packages including:
 
 - Development tools: git, gh, mise, devbox, uv, pnpm
 - Terminal tools: ghostty, vim, fzf, tree
-- macOS utilities: alt-tab-macos, raycast, rectangle, superfile
+- macOS utilities: alt-tab-macos, raycast, superfile
 - Applications: arc-browser, discord, vscode
 
 ## Customization


### PR DESCRIPTION
## Summary
Update README to remove Rectangle from the package list, as it was already removed in PR #44.

## Changes
- Removed `rectangle` from the macOS utilities list in README

## Context
Rectangle package was removed in PR #44 (issue #43), but the README was not updated at that time.
This PR completes the cleanup by updating the documentation.

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)