### PR TITLE
feat: remove alt-tab-macos package

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The configuration installs various packages including:
 
 - Development tools: git, gh, mise, devbox, uv, pnpm
 - Terminal tools: ghostty, vim, fzf, tree
-- macOS utilities: alt-tab-macos, raycast, superfile
+- macOS utilities: raycast, superfile
 - Applications: arc-browser, discord, vscode
 
 ## Customization

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,6 @@
               programs.zsh.enable = true;
 
               environment.systemPackages = (with pkgs; [
-                alt-tab-macos
                 devbox
                 discord
                 fzf


### PR DESCRIPTION
## Summary
Remove alt-tab-macos package and rely on Raycast for window switching functionality.

## Changes
- Removed `alt-tab-macos` from systemPackages in flake.nix
- Updated README to remove alt-tab-macos from the macOS utilities list

## Rationale
Raycast provides built-in window switching capabilities that can replace alt-tab-macos functionality. This reduces the number of packages needed and simplifies the configuration.

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)