### PR TITLE
revert: restore alt-tab-macos package

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The configuration installs various packages including:
 
 - Development tools: git, gh, mise, devbox, uv, pnpm
 - Terminal tools: ghostty, vim, fzf, tree
-- macOS utilities: raycast, superfile
+- macOS utilities: alt-tab-macos, raycast, superfile
 - Applications: arc-browser, discord, vscode
 
 ## Customization

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
               programs.zsh.enable = true;
 
               environment.systemPackages = (with pkgs; [
+                alt-tab-macos
                 devbox
                 discord
                 fzf


### PR DESCRIPTION
## Summary
Revert PR #51 to restore the alt-tab-macos package.

## Reason for Revert
While Raycast does have window switching capabilities, it provides a different user experience:
- **Raycast Window Switcher**: Text-based search and switching, keyboard-centric
- **AltTab**: Visual preview-based switching similar to Windows, more intuitive for visual users

The removal was premature without properly evaluating user preferences and the differences in functionality.

## Changes
This PR reverts commit 89912be which:
- Restores `alt-tab-macos` to systemPackages in flake.nix
- Updates README to include alt-tab-macos in the macOS utilities list

Fixes #52
Reverts #51

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>