### PR TITLE
fix: make Serena config file writable for dynamic updates

### DIFF
--- a/home-manager/claude.nix
+++ b/home-manager/claude.nix
@@ -26,12 +26,16 @@
     checkpointingEnabled = true;
   };
 
-  # Serena config
-  home.file.".serena/serena_config.yml".text = ''
-    gui_log_window: false
-    web_dashboard: false
-
-  '';
+  # Serena config (only create if it doesn't exist)
+  home.file.".serena/serena_config.yml" = {
+    text = ''
+      gui_log_window: false
+      web_dashboard: false
+      projects: {}
+    '';
+    # Only create if file doesn't exist, allowing Serena to manage it
+    force = false;
+  };
 
   # Global Claude Code memory
   home.file.".claude/CLAUDE.md".text = ''


### PR DESCRIPTION
## Summary
- Fix Serena MCP server configuration readonly issue
- Use `force = false` to prevent overwriting existing config files
- Allow Serena to dynamically manage the projects section

## Test plan
- [ ] Verify home-manager configuration applies successfully
- [ ] Confirm Serena can modify the config file after initial creation
- [ ] Test that projects can be added/removed dynamically

🤖 Generated with [Claude Code](https://claude.ai/code)