### PR TITLE
fix: make Claude settings.json writable for dynamic updates

### DIFF
--- a/home-manager/claude.nix
+++ b/home-manager/claude.nix
@@ -6,24 +6,28 @@
 }:
 
 {
-  # Explicitly set default values (as of 2025/08/13)
-  home.file.".claude/settings.json".text = builtins.toJSON {
-    installMethod = "unknown";
-    autoUpdates = true;
-    theme = "dark-daltonized";
-    verbose = false;
-    preferredNotifChannel = "auto";
-    shiftEnterKeyBindingInstalled = true;
-    editorMode = "normal";
-    hasUsedBackslashReturn = true;
-    autoCompactEnabled = true;
-    diffTool = "auto";
-    env = { };
-    todoFeatureEnabled = true;
-    messageIdleNotifThresholdMs = 60000;
-    autoConnectIde = false;
-    autoInstallIdeExtension = true;
-    checkpointingEnabled = true;
+  # Explicitly set default values (as of 2025/08/13) - only create if it doesn't exist
+  home.file.".claude/settings.json" = {
+    text = builtins.toJSON {
+      installMethod = "unknown";
+      autoUpdates = true;
+      theme = "dark-daltonized";
+      verbose = false;
+      preferredNotifChannel = "auto";
+      shiftEnterKeyBindingInstalled = true;
+      editorMode = "normal";
+      hasUsedBackslashReturn = true;
+      autoCompactEnabled = true;
+      diffTool = "auto";
+      env = { };
+      todoFeatureEnabled = true;
+      messageIdleNotifThresholdMs = 60000;
+      autoConnectIde = false;
+      autoInstallIdeExtension = true;
+      checkpointingEnabled = true;
+    };
+    # Only create if file doesn't exist, allowing Claude Code to manage it
+    force = false;
   };
 
   # Serena config (only create if it doesn't exist)


### PR DESCRIPTION
## Summary
- Fix Claude Code settings.json readonly issue
- Use `force = false` to prevent overwriting existing config files
- Allow Claude Code to manage its own settings after initial creation

## Test plan
- [ ] Verify home-manager configuration applies successfully
- [ ] Confirm Claude Code can modify settings.json after initial creation
- [ ] Test that settings persist across home-manager rebuilds

🤖 Generated with [Claude Code](https://claude.ai/code)